### PR TITLE
Update docs to note that it installs as `eztables`, not `django-eztables`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ or with easy_install:
     $ easy_install django-eztables
 
 
-Add ``djangojs`` and ``django-eztables`` to your ``settings.INSTALLED_APPS``.
+Add ``djangojs`` and ``eztables`` to your ``settings.INSTALLED_APPS``.
 
 
 Features

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -31,7 +31,7 @@ or with easy_install:
     $ easy_install django-eztables
 
 
-Add ``djangojs`` and ``django-eztables`` to your ``settings.INSTALLED_APPS``.
+Add ``djangojs`` and ``eztables`` to your ``settings.INSTALLED_APPS``.
 
 
 Features


### PR DESCRIPTION
I updated the docs to note that it installs as `eztables`, not `django-eztables`.

If you add `django-eztables` to your `INSTALLED_APPS`, you'll get an error:

```
Error: No module named django-eztables
```

Which makes sense because `-` isn't valid in a python module name.
