### PR TITLE
Enable use of @property's and callables in fields

### DIFF
--- a/eztables/views.py
+++ b/eztables/views.py
@@ -187,18 +187,18 @@ class DatatablesView(MultipleObjectMixin, View):
         num_page = (start_index / page_size) + 1
         return paginator.page(num_page)
 
-     def get_field_value(self, row, field, value_field):
-         if callable(value_field):
-             return value_field(row)
-         elif RE_FORMATTED.match(value_field):
-             return field, text_type(value_field).format(**row)
-         elif value_field.find('__') > 0:
-             fields = value_field.split("__")
-             for subattr in fields:
-                 row = getattr(row, subattr)
-             return row
-         else:
-             return getattr(row, value_field)
+    def get_field_value(self, row, field, value_field):
+        if callable(value_field):
+            return value_field(row)
+        elif RE_FORMATTED.match(value_field):
+            return field, text_type(value_field).format(**row)
+        elif value_field.find('__') > 0:
+            fields = value_field.split("__")
+            for subattr in fields:
+                row = getattr(row, subattr)
+            return row
+        else:
+            return getattr(row, value_field)
 
     def get_rows(self, rows):
         '''Format all rows'''

--- a/eztables/views.py
+++ b/eztables/views.py
@@ -78,7 +78,7 @@ class DatatablesView(MultipleObjectMixin, View):
             fields = self.fields.values() if isinstance(self.fields, dict) else self.fields
             for field in fields:
                 if callable(field):
-                     continue
+                    continue
                 elif RE_FORMATTED.match(field):
                     self._db_fields.extend(RE_FORMATTED.findall(field))
                 else:

--- a/eztables/views.py
+++ b/eztables/views.py
@@ -190,12 +190,13 @@ class DatatablesView(MultipleObjectMixin, View):
      def get_field_value(self, row, field, value_field):
          if callable(value_field):
              return value_field(row)
-         if RE_FORMATTED.match(value_field):
+         elif RE_FORMATTED.match(value_field):
              return field, text_type(value_field).format(**row)
          elif value_field.find('__') > 0:
              fields = value_field.split("__")
-             obj = getattr(row, fields[0])
-             return getattr(obj, fields[1])
+             for subattr in fields:
+                 row = getattr(row, subattr)
+             return row
          else:
              return getattr(row, value_field)
 

--- a/eztables/views.py
+++ b/eztables/views.py
@@ -208,13 +208,13 @@ class DatatablesView(MultipleObjectMixin, View):
         '''Format a single row (if necessary)'''
 
         if isinstance(self.fields, dict):
-            return dict([(
-                field, self.get_field_value(row, field, value_field))
+            return dict([
+                (field, self.get_field_value(row, field, value_field))
                 for field, value_field in self.fields.items()
             ])
         else:
             return [text_type(field).format(**row) if RE_FORMATTED.match(field)
-                    else row[field]
+                    else getattr(row, field)
                     for field in self.fields]
 
     def render_to_response(self, form, **kwargs):

--- a/eztables/views.py
+++ b/eztables/views.py
@@ -191,14 +191,14 @@ class DatatablesView(MultipleObjectMixin, View):
         if callable(value_field):
             return value_field(row)
         elif RE_FORMATTED.match(value_field):
-            return field, text_type(value_field).format(**row)
+            return text_type(value_field).format(**row.__dict__)
         elif value_field.find('__') > 0:
             fields = value_field.split("__")
             for subattr in fields:
                 row = getattr(row, subattr)
             return row
         else:
-            return getattr(row, value_field)
+            return row.__dict__.get(value_field)
 
     def get_rows(self, rows):
         '''Format all rows'''
@@ -213,8 +213,8 @@ class DatatablesView(MultipleObjectMixin, View):
                 for field, value_field in self.fields.items()
             ])
         else:
-            return [text_type(field).format(**row) if RE_FORMATTED.match(field)
-                    else getattr(row, field)
+            return [text_type(field).format(**row.__dict__) if RE_FORMATTED.match(field)
+                    else self.get_field_value(row, field, field)
                     for field in self.fields]
 
     def render_to_response(self, form, **kwargs):


### PR DESCRIPTION
Hi @noirbizarre and folks. This has also been a issue with me. I wanted to display data defined as `@property`  and also transform the data to present it in a more pleasant way, with widgets, for example (in my specific case, I had a `Batch` object with a `printProgress` `@property` which I wanted to present as a progress bar.

So I made a patch.

This was the final result:

![bildschirmfoto 2014-12-18 um 23 48 25](https://cloud.githubusercontent.com/assets/1291350/5499120/740a7f48-8710-11e4-9ed8-3d2aa54a9f28.png)

This is how the DataTable was defined:

```
class BatchDatatablesView(DatatablesView):
    model = Batch
    fields = {
        'client':'client__name',
        'start':'start',
        'quantity':'quantity',
        'credential':'credential',
        'progress':showProgress,
    }
```

`credential` is a `@property` of `Batch`.

`showProgress` is a callable which takes the row (Django ORM single object) and returns a string to be displayed. In this case:

```
def showProgress(row):
    return """<div class="progressbar_outer">
<div class="progressbar_percentage" style="width: %d%%" />
</div>""" % row.printProgress
```

The present patch does not enable searching from properties or callables, but I don't think it would be a good idea anyway.

I'm opening a pull-request.
